### PR TITLE
Enforce using --color=never for egrep

### DIFF
--- a/create-dmg
+++ b/create-dmg
@@ -154,11 +154,11 @@ MOUNT_DIR="/Volumes/${VOLUME_NAME}"
 
 # try unmount dmg if it was mounted previously (e.g. developer mounted dmg, installed app and forgot to unmount it)
 echo "Unmounting disk image..."
-DEV_NAME=$(hdiutil info | egrep '^/dev/' | sed 1q | awk '{print $1}')
+DEV_NAME=$(hdiutil info | egrep --color=never '^/dev/' | sed 1q | awk '{print $1}')
 test -d "${MOUNT_DIR}" && hdiutil detach "${DEV_NAME}"
 
 echo "Mount directory: $MOUNT_DIR"
-DEV_NAME=$(hdiutil attach -readwrite -noverify -noautoopen "${DMG_TEMP_NAME}" | egrep '^/dev/' | sed 1q | awk '{print $1}')
+DEV_NAME=$(hdiutil attach -readwrite -noverify -noautoopen "${DMG_TEMP_NAME}" | egrep --color=never '^/dev/' | sed 1q | awk '{print $1}')
 echo "Device name:     $DEV_NAME"
 
 if ! test -z "$BACKGROUND_FILE"; then


### PR DESCRIPTION
When you have something like `export GREP_OPTIONS='--color=always'` in your .bash_profile, the `$DEV_NAME` variable contains special characters and `hdiutil detach` isn't working, this PR fixes it by turning colored grep output off.