### PR TITLE
Issue #63 - EULA file in Microsoft WordPad format can't be processed

### DIFF
--- a/support/dmg-license.py
+++ b/support/dmg-license.py
@@ -94,7 +94,7 @@ data 'STR#' (5002, "English") {
                 kind = 'RTF ' if license.lower().endswith('.rtf') else 'TEXT'
                 f.write('data \'%s\' (5000, "English") {\n' % kind)
                 def escape(s):
-                    return s.strip().replace('\\', '\\\\').replace('"', '\\"')
+                    return s.strip().replace('\\', '\\\\').replace('"', '\\"').replace('\0', '')
 
                 for line in l:
                     if len(line) < 1000:


### PR DESCRIPTION
Strip null characters that WordPad adds to files. They do nothing except break MacOS processing of the file as a resource