### PR TITLE
add option to set custom Rez path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All contents of source\_folder will be copied into the disk image.
 *   **--app-drop-link [x y]:** make a drop link to Applications, at location x, y
 *   **--ql-drop-link [x y]:** make a drop link to /Library/QuickLook, at location x, y
 *   **--eula [eula file]:** attach a license file to the dmg
+*   **--rez [rez path]:** specify custom path to Rez tool used to include license file
 *   **--no-internet-enable:** disable automatic mount&copy
 *   **--format:** specify the final image format (default is UDZO)
 *   **--add-file [target name] [path to source file] [x y]:** add additional file (option can be used multiple times)

--- a/create-dmg
+++ b/create-dmg
@@ -60,6 +60,8 @@ function usage() {
 	echo "      execute hdiutil in quiet mode"
 	echo "  --sandbox-safe"
 	echo "      execute hdiutil with sandbox compatibility and do not bless"
+	echo "  --rez rez_path"
+	echo "      use custom path to Rez tool"
 	echo "  --version         show tool version number"
 	echo "  -h, --help        display this help"
 	exit 0
@@ -167,6 +169,9 @@ while test "${1:0:1}" = "-"; do
 	--sandbox-safe)
 		SANDBOX_SAFE=1
 		shift;; 
+	--rez)
+		REZ_PATH=$2
+		shift; shift;;
 	-*)
 		echo "Unknown option $1. Run with --help for help."
 		exit 1;;
@@ -382,11 +387,20 @@ if [ ! -z "${EULA_RSRC}" -a "${EULA_RSRC}" != "-null-" ]; then
 	echo "adding EULA resources"
 
 	if [ $BREW_INSTALL -eq 0 ]; then
-		"${AUX_PATH}/dmg-license.py" "${DMG_DIR}/${DMG_NAME}" "${EULA_RSRC}"
+		if [ ! -z "${REZ_PATH}" -a "${REZ_PATH}" != "-null-" ]; then
+			"${AUX_PATH}/dmg-license.py" "--rez" "${REZ_PATH}" "${DMG_DIR}/${DMG_NAME}" "${EULA_RSRC}"
+		else
+			"${AUX_PATH}/dmg-license.py" "${DMG_DIR}/${DMG_NAME}" "${EULA_RSRC}"
+		fi
 	else
-		python - "${DMG_DIR}/${DMG_NAME}" "${EULA_RSRC}" << 'EOS'
-		# BREW_INLINE_LICENSE_PLACEHOLDER
-EOS
+		if [ ! -z "${REZ_PATH}" -a "${REZ_PATH}" != "-null-" ]; then
+			python - "--rez" "${REZ_PATH}" "${DMG_DIR}/${DMG_NAME}" "${EULA_RSRC}" <<-'EOS'
+			EOS
+		else
+			python - "${DMG_DIR}/${DMG_NAME}" "${EULA_RSRC}" <<-'EOS'
+			EOS
+			# BREW_INLINE_LICENSE_PLACEHOLDER
+		fi
 	fi
 fi
 


### PR DESCRIPTION
On some systems the Rez tool isn't installed on the default
/Applications/Xcode.app/Contents/Developer/Tools/Rez

Currently when using the --eula flag in order to embed a license in
the DMG file, the process can fail when the dmg-license.py script
is called if Rez can't be found in the default location.

This patch adds a --rez flag which allows users to specify a custom
Rez path which is then passed to dmg-license.py, as this script
already has support for using a custom Rez path.