### PR TITLE
Use xcode-select to locate Xcode

### DIFF
--- a/support/dmg-license.py
+++ b/support/dmg-license.py
@@ -29,6 +29,7 @@ import os
 import sys
 import tempfile
 import optparse
+import subprocess
 
 
 class Path(str):
@@ -129,6 +130,7 @@ data 'STR#' (5002, "English") {
         print("Failed to add license to '%s'" % dmgFile)
 
 if __name__ == '__main__':
+    xcode_developer = subprocess.check_output(['xcode-select', '-p']).rstrip()
     parser = optparse.OptionParser()
     parser.set_usage("""%prog <dmgFile> <licenseFile> [OPTIONS]
   This program adds a software license agreement to a DMG file.
@@ -140,7 +142,7 @@ if __name__ == '__main__':
         '--rez',
         '-r',
         action='store',
-        default='/Applications/Xcode.app/Contents/Developer/Tools/Rez',
+        default=xcode_developer+'/Tools/Rez',
         help='The path to the Rez tool. Defaults to %default'
     )
     parser.add_option(


### PR DESCRIPTION
How about using the standard `xcode-select` utility to locate Xcode, instead of assuming it's installed at the default location? For example, I like to keep multiple versioned Xcodes at e.g. `/Applications/Xcode-9.1`, `/Applications/Xcode-10.1`, and maybe `~/Applications/Xcode-11.whatever.beta`.

Pulls in Octave.app's customization from https://github.com/octave-app/create-dmg/commit/4576be1e60e8f86fdf9809083d4e7879be31edaf.