### PR TITLE
README: Use conventional brackets for option arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,32 +35,32 @@ Usage
 -----
 
 ```sh
-create-dmg [options...] [output\_name.dmg] [source\_folder]
+create-dmg [options ...] <output_name.dmg> <source_folder>
 ```
 
 All contents of source\_folder will be copied into the disk image.
 
 **Options:**
 
-*   **--volname [name]:** set volume name (displayed in the Finder sidebar and window title)
-*   **--volicon [icon.icns]:** set volume icon
-*   **--background [pic.png]:** set folder background image (provide png, gif, jpg)
-*   **--window-pos [x y]:** set position the folder window
-*   **--window-size [width height]:** set size of the folder window
-*   **--text-size [text size]:** set window text size (10-16)
-*   **--icon-size [icon size]:** set window icons size (up to 128)
-*   **--icon [file name] [x y]:** set position of the file's icon
-*   **--hide-extension [file name]:** hide the extension of file
-*   **--custom-icon [file name]/[custom icon]/[sample file] [x y]:** set position and custom icon
-*   **--app-drop-link [x y]:** make a drop link to Applications, at location x, y
-*   **--ql-drop-link [x y]:** make a drop link to /Library/QuickLook, at location x, y
-*   **--eula [eula file]:** attach a license file to the dmg
-*   **--rez [rez path]:** specify custom path to Rez tool used to include license file
+*   **--volname \<name\>:** set volume name (displayed in the Finder sidebar and window title)
+*   **--volicon \<icon.icns\>:** set volume icon
+*   **--background \<pic.png\>:** set folder background image (provide png, gif, jpg)
+*   **--window-pos \<x\> \<y\>:** set position the folder window
+*   **--window-size \<width\> \<height\>:** set size of the folder window
+*   **--text-size \<text_size\>:** set window text size (10-16)
+*   **--icon-size \<icon_size\>:** set window icons size (up to 128)
+*   **--icon \<file_name\> \<x\> \<y\>:** set position of the file's icon
+*   **--hide-extension \<file_name\>:** hide the extension of file
+*   **--custom-icon \<file_name|custom_icon|sample_file\> \<x\> \<y\>:** set position and custom icon
+*   **--app-drop-link \<x\> \<y\>:** make a drop link to Applications, at location x, y
+*   **--ql-drop-link \<x\> \<y\>:** make a drop link to /Library/QuickLook, at location x, y
+*   **--eula \<eula_file\>:** attach a license file to the dmg
+*   **--rez \<rez_path\>:** specify custom path to Rez tool used to include license file
 *   **--no-internet-enable:** disable automatic mount&copy
 *   **--format:** specify the final image format (default is UDZO)
-*   **--add-file [target name] [path to source file] [x y]:** add additional file (option can be used multiple times)
-*   **--add-folder [target name] [path to source folder] [x y]:** add additional folder (option can be used multiple times)
-*   **--disk-image-size [x]:** set the disk image size manually to x MB
+*   **--add-file \<target_name\> \<path_to_source_file\> \<x\> \<y\>:** add additional file (option can be used multiple times)
+*   **--add-folder \<target_name\> \<path_to_source_folder\> \<x\> \<y\>:** add additional folder (option can be used multiple times)
+*   **--disk-image-size \<x\>:** set the disk image size manually to x MB
 *   **--hdiutil-verbose:** execute hdiutil in verbose mode
 *   **--hdiutil-quiet:** execute hdiutil in quiet mode
 *   **--sandbox-safe:** execute hdiutil with sandbox compatibility and don not bless


### PR DESCRIPTION
In `man` pages and program `--help` output, it's conventional to use angle brackets to indicate required arguments, and square brackets to indicate optional arguments. And vertical pipes to indicate alternatives. How about adopting those conventions in the README, too?